### PR TITLE
Add Terraform doc references

### DIFF
--- a/content/posts/modules.md
+++ b/content/posts/modules.md
@@ -47,4 +47,6 @@ module "s3" {
 
 In the next section we will learn how to use variables and how they can help us to create logical abstractions from our Terraform modules.
 
+Want to learn more about Modules? [Check out the docs](https://www.terraform.io/language/modules).
+
 **Continue to [Variables](../variables)**

--- a/content/posts/outputs.md
+++ b/content/posts/outputs.md
@@ -29,7 +29,7 @@ output "example_compute_instance_name" {
 
 #### Declaring a sensitive output value
 
-Sensitive values are masked in the output of `terraform plan` and `terraform apply`. 
+Sensitive values are masked in the output of `terraform plan` and `terraform apply`.
 
 > Note: Terraform will persist the value to the state file as cleartext, anyone that can view the state file can see the value.
 
@@ -57,3 +57,7 @@ resource "google_compute_instance_iam_member" "member" {
   member        = "user:bruno@example.com"
 }
 ```
+
+Want to learn more about Outputs? [Check out the docs](https://www.terraform.io/language/values/outputs).
+
+**Continue to [Operators](../operators)**

--- a/content/posts/providers.md
+++ b/content/posts/providers.md
@@ -26,4 +26,6 @@ provider "google" {
 
 Every provider has a set of arguments that are used to configure the provider, look up the respective provider documentation for more information.
 
+Want to learn more about Providers? [Check out the docs](https://www.terraform.io/language/providers).
+
 **Continue to [Modules](../modules)**

--- a/content/posts/variables.md
+++ b/content/posts/variables.md
@@ -69,3 +69,7 @@ module "s3" {
   bucket_name = "my-bucket"
 }
 ```
+
+Want to learn more about Variables? [Check out the docs](https://www.terraform.io/language/values/variables).
+
+**Continue to [Outputs](../outputs)**


### PR DESCRIPTION
Every page should have a reference to the respective Terrafom documentation in case a reader wants to learn more about a langauge feature.