### PR TITLE
chore: add missing "continue" refs on pages

### DIFF
--- a/content/posts/conditionals.md
+++ b/content/posts/conditionals.md
@@ -64,3 +64,5 @@ resource "aws_elasticache_cluster" "example" {
 ```
 
 Want to learn more about Conditionals? [Check out the docs](https://www.terraform.io/language/expressions/conditionals).
+
+**Continue to [For](../for)**

--- a/content/posts/dynamics.md
+++ b/content/posts/dynamics.md
@@ -61,3 +61,5 @@ The iterator object, `allow` in the example above has 2 attributes:
 - `value` - Map value corresponding to the current iteration. (If a set was provided, it would have the same value as the `each.key` has).
 
 Want to learn more about the Dynamics expression? [Check out the docs](https://www.terraform.io/language/expressions/dynamic-blocks).
+
+**Continue to [Splat](../splat)**

--- a/content/posts/for.md
+++ b/content/posts/for.md
@@ -70,4 +70,4 @@ locals {
 
 Want to learn more about For loops? [Check out the docs](https://www.terraform.io/language/expressions/for).
 
-**Continue to [For each](../foreach)**
+**Continue to [For each](../for_each)**

--- a/content/posts/for_each.md
+++ b/content/posts/for_each.md
@@ -45,3 +45,5 @@ This object has 2 attributes:
 - `each.value` - Map value corresponding to the current iteration. (If a set was provided, it would have the same value as the `each.key` has).
 
 Want to learn more about the for_each argument? [Check out the docs](https://www.terraform.io/language/meta-arguments/for_each).
+
+**Continue to [Dynamics](../dynamics)**

--- a/content/posts/splat.md
+++ b/content/posts/splat.md
@@ -38,3 +38,5 @@ You can't refer to a resource using the splat operator `[*]` if the resource use
 The splat operator applies only to lists.
 
 Want to learn more about splat expressions? [Check out the docs](https://www.terraform.io/language/expressions/splat).
+
+**Continue to [Data Sources](../data_sources)**


### PR DESCRIPTION
## What
* Puts the "Continue to.." on every page.

## Why
* It makes navigating the website easier, and other pages had it already.

## References
* Closes #44
